### PR TITLE
Update 20140505000000_create_re_relationtypes.rb

### DIFF
--- a/db/migrate/20140505000000_create_re_relationtypes.rb
+++ b/db/migrate/20140505000000_create_re_relationtypes.rb
@@ -18,7 +18,7 @@ class CreateReRelationtypes < ActiveRecord::Migration
       t.integer :in_use
     end
     
-    ReArtifactProperties.where(artifact_type: 'Project').each do |project|
+    ReArtifactProperties.where({:artifact_type => 'Project'}).each do |project|
       ReRelationtype.new(:project_id => project.project_id, :relation_type => "parentchild",   :alias_name => "parentchild", :color => "#0000ff", :is_system_relation => "1", :is_directed => "1", :in_use => "1").save
       ReRelationtype.new(:project_id => project.project_id, :relation_type => "primary_actor", :alias_name => "primary_actor", :color => "#ff99cc", :is_system_relation => "1", :is_directed => "1", :in_use => "1").save
       ReRelationtype.new(:project_id => project.project_id, :relation_type => "actors",        :alias_name => "actors",  :color => "#ff00ff", :is_system_relation => "1", :is_directed => "1", :in_use => "1").save


### PR DESCRIPTION
Because in ruby1.8 I get error:

rake redmine:plugins:migrate --trace
** Invoke redmine:plugins:migrate (first_time)
** Invoke environment (first_time)
** Execute environment
** Execute redmine:plugins:migrate
Migrating redmine_re (Redmine Requirements Engineering Plugin)...
rake aborted!
SyntaxError: /usr/share/redmine/plugins/redmine_re/db/migrate/20140505000000_create_re_relationtypes.rb:21: syntax error, unexpected ':', expecting ')'
...roperties.where(artifact_type: 'Project').each do |project|
                              ^
/usr/share/redmine/plugins/redmine_re/db/migrate/20140505000000_create_re_relationtypes.rb:21: syntax error, unexpected ')', expecting kEND
...here(artifact_type: 'Project').each do |project|