### PR TITLE
Towards redmine 3 compatibility

### DIFF
--- a/app/controllers/re_artifact_properties_controller.rb
+++ b/app/controllers/re_artifact_properties_controller.rb
@@ -23,7 +23,7 @@ class ReArtifactPropertiesController < RedmineReController
       logger.debug("#{@re_artifact_properties.artifact.class} does not implement new hook")
     end    
     @secondary_user_profiles = []
-    @user_profiles = ReArtifactProperties.find_all_by_artifact_type_and_project_id('ReUserProfile', @project.id)
+    @user_profiles = ReArtifactProperties.where(project_id: @project.id, artifact_type: 'ReUserProfile')
 
     unless params[:sibling_artifact_id].blank?
       sibling = ReArtifactProperties.find(params[:sibling_artifact_id])
@@ -161,7 +161,7 @@ class ReArtifactPropertiesController < RedmineReController
         
     if @project.enabled_module_names.include? 'diagrameditor'
       @relation_to_diagrams = ReArtifactRelationship.find_by_source_id_and_relation_type(@re_artifact_properties.id, 'diagram') 
-      @related_diagrams = ConcreteDiagram.find_all_by_id(@relation_to_diagrams.sink_id) unless @relation_to_diagrams.nil?           
+      @related_diagrams = ConcreteDiagram.where(id: @relation_to_diagrams.sink_id) unless @relation_to_diagrams.nil?           
     end
 
     begin

--- a/app/controllers/re_artifact_relationship_controller.rb
+++ b/app/controllers/re_artifact_relationship_controller.rb
@@ -16,14 +16,14 @@ class ReArtifactRelationshipController < RedmineReController
     end
 
     @artifact_properties = ReArtifactProperties.find(params[:re_artifact_properties_id])
-    @relationships_incoming = ReArtifactRelationship.find_all_by_sink_id(params[:re_artifact_properties_id])
+    @relationships_incoming = ReArtifactRelationship.where(sink_id: params[:re_artifact_properties_id])
     @relationships_incoming.delete_if {|rel| ReArtifactRelationship::SYSTEM_RELATION_TYPES.values.include?(rel.relation_type) }
 
     unless params[:secondary_user_delete].blank?
-      @relationships_outgoing = ReArtifactRelationship.find_all_by_source_id_and_relation_type(params[:re_artifact_properties_id],ReArtifactRelationship::RELATION_TYPES[:dep])
+      @relationships_outgoing = ReArtifactRelationship.where(source_id: params[:re_artifact_properties_id], relation_type: ReArtifactRelationship::RELATION_TYPES[:dep])
       render :partial => "secondary_user", :project_id => params[:project_id]
     else
-      @relationships_outgoing = ReArtifactRelationship.find_all_by_source_id(params[:re_artifact_properties_id])
+      @relationships_outgoing = ReArtifactRelationship.where(source_id: params[:re_artifact_properties_id])
       @relationships_outgoing.delete_if {|rel| ReArtifactRelationship::SYSTEM_RELATION_TYPES.values.include?(rel.relation_type) }
       render :partial => "relationship_links", :project_id => params[:project_id]
     end
@@ -60,9 +60,9 @@ class ReArtifactRelationshipController < RedmineReController
     logger.debug("tried saving the following relation (errors: #{@new_relation.errors.size}): " + @new_relation.to_yaml) 
 
     @artifact_properties = ReArtifactProperties.find(artifact_properties_id)
-    @relationships_outgoing = ReArtifactRelationship.find_all_by_source_id(artifact_properties_id)
+    @relationships_outgoing = ReArtifactRelationship.where(source_id: artifact_properties_id)
     @relationships_outgoing.delete_if {|rel| ReArtifactRelationship::SYSTEM_RELATION_TYPES.values.include?(rel.relation_type) }
-    @relationships_incoming = ReArtifactRelationship.find_all_by_sink_id(artifact_properties_id)
+    @relationships_incoming = ReArtifactRelationship.where(sink_id: artifact_properties_id)
     @relationships_incoming.delete_if {|rel| ReArtifactRelationship::SYSTEM_RELATION_TYPES.values.include?(rel.relation_type) }
 
     render :partial => "relationship_links", :layout => false, :project_id => params[:project_id]
@@ -170,7 +170,7 @@ class ReArtifactRelationshipController < RedmineReController
     
     artifacts.each do |artifact|
       outgoing_relationships = ReArtifactRelationship.find_all_relations_for_artifact_id(artifact.id)
-      drawable_relationships = ReArtifactRelationship.find_all_by_source_id_and_relation_type(artifact.id, relations)
+      drawable_relationships = ReArtifactRelationship.where(source_id: artifact.id, relation_type: relations)
       artifact_ids = @artifacts.collect { |a| a.id }
       drawable_relationships.delete_if { |r| ! artifact_ids.include? r.sink_id }
       json << add_artifact(artifact, drawable_relationships, outgoing_relationships)
@@ -293,7 +293,7 @@ class ReArtifactRelationshipController < RedmineReController
         next unless ( ! @done_artifakts_id.include? child.id.to_s)
         @done_artifakts_id << artifact.id.to_s
         outgoing_relationships = ReArtifactRelationship.find_all_relations_for_artifact_id(child.id)
-        drawable_relationships = ReArtifactRelationship.find_all_by_source_id(child.id)
+        drawable_relationships = ReArtifactRelationship.where(source_id: child.id)
         json_artifact = add_artifact(child, drawable_relationships, outgoing_relationships)
         json_return = sunburst(child)
         if (json_return != [])
@@ -326,7 +326,7 @@ class ReArtifactRelationshipController < RedmineReController
       ReRealization.where("issue_id=?", issue_id.to_s).each do |artifact| 
         if( ! @done_artifakts_id.include? artifact.re_artifact_properties_id.to_s)
           outgoing_relationships = ReArtifactRelationship.find_all_relations_for_artifact_id(artifact.re_artifact_properties_id)
-          drawable_relationships = ReArtifactRelationship.find_all_by_source_id(artifact.re_artifact_properties_id)
+          drawable_relationships = ReArtifactRelationship.where(source_id: artifact.re_artifact_properties_id)
           child = ReArtifactProperties.find_by_project_id_and_id(@project.id,artifact.re_artifact_properties_id) 
        
           json_artifact = add_artifact(child, drawable_relationships, outgoing_relationships)
@@ -354,7 +354,7 @@ class ReArtifactRelationshipController < RedmineReController
     
     if (@max_deep.to_i == 0 || @current_deep.to_i <= @max_deep.to_i)
       if ( ! @done_artifakts_id.include? artifact.id.to_s)
-          ReArtifactRelationship.find_all_by_source_id(artifact.id).each do |source|
+          ReArtifactRelationship.where(source_id: artifact.id).each do |source|
             next unless (@chosen_artifacts.include? ReArtifactProperties.find_by_id(source.sink_id).artifact_type.to_s)
             next unless (@chosen_relations.include? ReArtifactRelationship.find_by_id(source.id).relation_type.to_s)
             
@@ -382,7 +382,7 @@ class ReArtifactRelationshipController < RedmineReController
               @source_artifakts_id << source.source_id
             end
           end
-          ReArtifactRelationship.find_all_by_sink_id(artifact.id).each do |source|
+          ReArtifactRelationship.where(sink_id: artifact.id).each do |source|
             next unless (@chosen_artifacts.include? ReArtifactProperties.find_by_id(source.source_id).artifact_type.to_s)
             next unless (@chosen_relations.include? ReArtifactRelationship.find_by_id(source.id).relation_type.to_s)
             if (@current_deep.to_i  == @max_deep.to_i)
@@ -520,7 +520,7 @@ class ReArtifactRelationshipController < RedmineReController
         @done_artifakts_id << artifact.id.to_s  
       end
 
-      ReArtifactRelationship.find_all_by_source_id(artifact.id).each do |source|
+      ReArtifactRelationship.where(source_id: artifact.id).each do |source|
         next unless (@chosen_artifacts.include? ReArtifactProperties.find_by_id(source.sink_id).artifact_type.to_s)
         next unless (@chosen_relations.include? ReArtifactRelationship.find_by_id(source.id).relation_type.to_s)
         next unless ( ! @done_artifakts_id.include? source.sink_id.to_s)
@@ -537,7 +537,7 @@ class ReArtifactRelationshipController < RedmineReController
         end
       end 
     
-      ReArtifactRelationship.find_all_by_sink_id(artifact.id).each do |source|
+      ReArtifactRelationship.where(sink_id: artifact.id).each do |source|
         next unless (@chosen_artifacts.include? ReArtifactProperties.find_by_id(source.source_id).artifact_type.to_s)
         next unless (@chosen_relations.include? ReArtifactRelationship.find_by_id(source.id).relation_type.to_s)
         next unless ( ! @done_artifakts_id.include? source.source_id.to_s)
@@ -775,13 +775,13 @@ class ReArtifactRelationshipController < RedmineReController
         @found_artifakts << artifact
         @done_artifakts_id << artifact.id.to_s
       end
-      ReArtifactRelationship.find_all_by_source_id(artifact.id).each do |source|
+      ReArtifactRelationship.where(source_id: artifact.id).each do |source|
         next unless (@chosen_artifacts.include? ReArtifactProperties.find_by_id(source.sink_id).artifact_type.to_s)
         next unless (@chosen_relations.include? ReArtifactRelationship.find_by_id(source.id).relation_type.to_s)
         next unless ( ! @done_artifakts_id.include? source.sink_id.to_s)
         find_all_artifacts_for_netmap(ReArtifactProperties.find_by_project_id_and_id(@project.id, source.sink_id))  
       end 
-      ReArtifactRelationship.find_all_by_sink_id(artifact.id).each do |source|
+      ReArtifactRelationship.where(sink_id: artifact.id).each do |source|
         next unless (@chosen_artifacts.include? ReArtifactProperties.find_by_id(source.source_id).artifact_type.to_s)
         next unless (@chosen_relations.include? ReArtifactRelationship.find_by_id(source.id).relation_type.to_s)
         next unless ( ! @done_artifakts_id.include? source.source_id.to_s)
@@ -1076,7 +1076,7 @@ class ReArtifactRelationshipController < RedmineReController
     @max_deep = ReVisualizationConfig.get_max_deep(@project.id, session[:visualization_type]).to_i
 
     if(@visualization_type!= "graph_issue" )
-      @artifacts = ReArtifactProperties.find_all_by_project_id_and_artifact_type(@project.id, @chosen_artifacts, :order => "artifact_type, name")
+      @artifacts = ReArtifactProperties.where(project_id: @project.id, artifact_type: @chosen_artifacts ).order("artifact_type, name")
     else
       @artifacts = ""
     end
@@ -1087,7 +1087,7 @@ class ReArtifactRelationshipController < RedmineReController
   
   def min_dis_artifact(artifact_id)
     @current_deep = @current_deep + 1
-    ReArtifactRelationship.find_all_by_source_id(artifact_id).each do |source|
+    ReArtifactRelationship.where(source_id: artifact_id).each do |source|
       next unless (@chosen_artifacts.include? ReArtifactProperties.find_by_id(source.sink_id).artifact_type.to_s)
       next unless (@chosen_relations.include? ReArtifactRelationship.find_by_id(source.id).relation_type.to_s)
      
@@ -1100,7 +1100,7 @@ class ReArtifactRelationshipController < RedmineReController
       end
     end 
     if(@visualization_type != "sunburst")
-      ReArtifactRelationship.find_all_by_sink_id(artifact_id).each do |source|
+      ReArtifactRelationship.where(sink_id: artifact_id).each do |source|
         next unless (@chosen_artifacts.include? ReArtifactProperties.find_by_id(source.source_id).artifact_type.to_s)
         next unless (@chosen_relations.include? ReArtifactRelationship.find_by_id(source.id).relation_type.to_s)
         if (@min_dis_artifact_arr[source.source_id] == nil || @min_dis_artifact_arr[source.source_id] > @current_deep)

--- a/app/controllers/re_settings_controller.rb
+++ b/app/controllers/re_settings_controller.rb
@@ -47,7 +47,7 @@ class ReSettingsController < RedmineReController
     end
 
     @re_relation_configs = {}
-    @re_relation_types = ReRelationtype.find_all_by_project_id(@project.id)
+    @re_relation_types = ReRelationtype.where(project_id: @project.id)
     logger.debug @re_relation_types.inspect
     @re_settings = {}
     @re_settings["visualization_size"] = ReSetting.get_plain("visualization_size", @project.id)
@@ -184,7 +184,7 @@ private
         else
           if v[:destroy] == "1"
             
-            n = ReArtifactRelationship.find_all_by_relation_type(r.relation_type)
+            n = ReArtifactRelationship.where(relation_type: r.relation_type)
             n.each do |relation|
               artifact = ReArtifactProperties.find(relation.source_id)
               if (artifact.project_id == r.project_id)

--- a/app/models/re_artifact_properties.rb
+++ b/app/models/re_artifact_properties.rb
@@ -47,20 +47,20 @@ class ReArtifactProperties < ActiveRecord::Base
            :dependent => :destroy
            
   has_one :parent_relation,
-    -> {where(re_artifact_relationships[:relation_type] => ReArtifactRelationship::SYSTEM_RELATION_TYPES[:pch]).order("re_artifact_relationships.position")},
+    -> {where("re_artifact_relationships.relation_type" => ReArtifactRelationship::SYSTEM_RELATION_TYPES[:pch]).order("re_artifact_relationships.position")},
           :foreign_key => "sink_id",
           :class_name => "ReArtifactRelationship",
           :dependent => :destroy
 
   has_many :child_relations,
-    -> {where(re_artifact_relationships[:relation_type] => ReArtifactRelationship::SYSTEM_RELATION_TYPES[:pch]).order("re_artifact_relationships.position")},
+    -> {where("re_artifact_relationships.relation_type" => ReArtifactRelationship::SYSTEM_RELATION_TYPES[:pch]).order("re_artifact_relationships.position")},
            :foreign_key => "source_id",
            :class_name => "ReArtifactRelationship",
            :dependent => :destroy
 
            #######
   has_many :primary_relations,
-    -> {where(re_artifact_relationships[:relation_type] => ReArtifactRelationship::SYSTEM_RELATION_TYPES[:pac]).order("re_artifact_relationships.position")},
+    -> {where("re_artifact_relationships.relation_type" => ReArtifactRelationship::SYSTEM_RELATION_TYPES[:pac]).order("re_artifact_relationships.position")},
            :foreign_key => "source_id",
            :class_name => "ReArtifactRelationship",
            :dependent => :destroy

--- a/app/models/re_artifact_properties.rb
+++ b/app/models/re_artifact_properties.rb
@@ -139,7 +139,7 @@ class ReArtifactProperties < ActiveRecord::Base
       :type => 're_artifact_properties',
       :timestamp => "#{ReArtifactProperties.table_name}.updated_at",
       :author_key => "#{ReArtifactProperties.table_name}.updated_by",
-      :find_options => {:include => [:project, :user]},
+      :scope => includes(:project, :user),
       :permission => :edit_requirements
   )
 

--- a/app/models/re_artifact_properties.rb
+++ b/app/models/re_artifact_properties.rb
@@ -3,7 +3,7 @@ class ReArtifactProperties < ActiveRecord::Base
 
   #attr_accessible :artifact_type
 
-  scope :without_projects, :conditions => ["artifact_type != ?", 'Project']
+  scope :without_projects, lambda {where("artifact_type != ?", 'Project')}
   scope :of_project, lambda { |project|
     project_id = (project.is_a? Project) ? project.id : project
     {:conditions => {:project_id => project_id}}
@@ -12,96 +12,111 @@ class ReArtifactProperties < ActiveRecord::Base
   has_many :re_ratings, :dependent => :destroy
   
   has_many :raters, :through => :re_ratings, :source => :users
-  has_many :comments, :as => :commented, :dependent => :destroy, :order => "created_on asc"
+  has_many :comments, -> {order("created_on ASC")}, :as => :commented, :dependent => :destroy
   has_many :re_realizations, :dependent => :destroy
-  has_many :issues, :through => :re_realizations, :uniq => true
+  has_many :issues, -> {uniq(true)}, :through => :re_realizations
 
   has_many :relationships_as_source,
-           :order => "re_artifact_relationships.position",
+    -> {order("re_artifact_relationships.position")},
            :foreign_key => "source_id",
            :class_name => "ReArtifactRelationship",
            :dependent => :destroy
 
   has_many :relationships_as_sink,
-           :order => "re_artifact_relationships.position",
+    -> {order("re_artifact_relationships.position")},
            :foreign_key => "sink_id",
            :class_name => "ReArtifactRelationship",
            :dependent => :destroy
 
   has_many :traces_as_source,
-           :order => "re_artifact_relationships.position",
+    -> {where.not(re_artifact_relationships[:relation_type].in(ReArtifactRelationship::SYSTEM_RELATION_TYPES)).order("re_artifact_relationships.position")},
            :foreign_key => "source_id",
            :class_name => "ReArtifactRelationship",
-           :conditions => ["re_artifact_relationships.relation_type NOT IN (?)", ReArtifactRelationship::SYSTEM_RELATION_TYPES],
            :dependent => :destroy
 
   has_many :traces_as_sink,
-           :order => "re_artifact_relationships.position",
+    -> {where.not(re_artifact_relationships[:relation_type].in(ReArtifactRelationship::SYSTEM_RELATION_TYPES)).order("re_artifact_relationships.position")},
            :foreign_key => "sink_id",
            :class_name => "ReArtifactRelationship",
-           :conditions => ["re_artifact_relationships.relation_type NOT IN (?)", ReArtifactRelationship::SYSTEM_RELATION_TYPES],
            :dependent => :destroy
  
   has_many :user_defined_relations,
-           :order => "re_artifact_relationships.position",   
+    -> {where.not(re_artifact_relationships[:relation_type].in(ReArtifactRelationship::SYSTEM_RELATION_TYPES)).order("re_artifact_relationships.position")},
            :foreign_key => "source_id",
            :class_name => "ReArtifactRelationship",
-           :conditions => ["re_artifact_relationships.relation_type NOT IN (?)", ReArtifactRelationship::SYSTEM_RELATION_TYPES],
            :dependent => :destroy
            
   has_one :parent_relation,
-          :order => "re_artifact_relationships.position",
+    -> {where(re_artifact_relationships[:relation_type] => ReArtifactRelationship::SYSTEM_RELATION_TYPES[:pch]).order("re_artifact_relationships.position")},
           :foreign_key => "sink_id",
           :class_name => "ReArtifactRelationship",
-          :conditions => ["re_artifact_relationships.relation_type = ?", ReArtifactRelationship::SYSTEM_RELATION_TYPES[:pch]],
           :dependent => :destroy
 
   has_many :child_relations,
-           :order => "re_artifact_relationships.position",
+    -> {where(re_artifact_relationships[:relation_type] => ReArtifactRelationship::SYSTEM_RELATION_TYPES[:pch]).order("re_artifact_relationships.position")},
            :foreign_key => "source_id",
            :class_name => "ReArtifactRelationship",
-           :conditions => ["re_artifact_relationships.relation_type = ?", ReArtifactRelationship::SYSTEM_RELATION_TYPES[:pch]],
            :dependent => :destroy
 
            #######
   has_many :primary_relations,
-           :order => "re_artifact_relationships.position",
+    -> {where(re_artifact_relationships[:relation_type] => ReArtifactRelationship::SYSTEM_RELATION_TYPES[:pac]).order("re_artifact_relationships.position")},
            :foreign_key => "source_id",
            :class_name => "ReArtifactRelationship",
-           :conditions => ["re_artifact_relationships.relation_type = ?", ReArtifactRelationship::SYSTEM_RELATION_TYPES[:pac]],
            :dependent => :destroy
            
   has_many :actors_relations,
-           :order => "re_artifact_relationships.position",
+    -> {where(re_artifact_relationships[:relation_type] => ReArtifactRelationship::SYSTEM_RELATION_TYPES[:ac]).order("re_artifact_relationships.position")},
            :foreign_key => "source_id",
            :class_name => "ReArtifactRelationship",
-           :conditions => ["re_artifact_relationships.relation_type = ?", ReArtifactRelationship::SYSTEM_RELATION_TYPES[:ac]],
            :dependent => :destroy
 
                     
-  has_many :diagram_relations,           
+  has_many :diagram_relations,  
+    -> {where( re_artifact_relationships[:relation_type] => ReArtifactRelationship::SYSTEM_RELATION_TYPES[:dia])},
            :foreign_key => "source_id",
            :class_name => "ReArtifactRelationship",
-           :conditions => ["re_artifact_relationships.relation_type = ?", ReArtifactRelationship::SYSTEM_RELATION_TYPES[:dia]],
            :dependent => :destroy
 
   has_many :related_diagrams, :through => :diagram_relations, :class_name => "ConcreteDiagram",  :source => "sink"
      
     
-  has_many :sinks,    :through => :traces_as_source, :order => "re_artifact_relationships.position"
-  has_many :children, :through => :child_relations,  :order => "re_artifact_relationships.position", :source => "sink"
+  has_many :sinks,    
+    -> {order("re_artifact_relationships.position")},
+           :through => :traces_as_source 
+  has_many :children,    
+    -> {order("re_artifact_relationships.position")},
+         :through => :child_relations,  :source => "sink"
   ###
-  has_many :primary, :through => :primary_relations,  :order => "re_artifact_relationships.position", :source => "sink"
-  has_many :actors, :through => :actors_relations,  :order => "re_artifact_relationships.position", :source => "sink"
-  has_many :dependency, :through => :dependency_relations,  :order => "re_artifact_relationships.position", :source => "sink"
-  has_many :conflict, :through => :conflict_relations,  :order => "re_artifact_relationships.position", :source => "sink"
-  has_many :rationale, :through => :rationale_relations,  :order => "re_artifact_relationships.position", :source => "sink"
-  has_many :refinement, :through => :refinement_relations,  :order => "re_artifact_relationships.position", :source => "sink"
-  has_many :part_of, :through => :part_of_relations,  :order => "re_artifact_relationships.position", :source => "sink"
-  has_many :diagram, :through => :diagram_relations,  :order => "re_artifact_relationships.position", :source => "sink"
+  has_many :primary,
+    -> {order("re_artifact_relationships.position")},
+         :through => :primary_relations,  :source => "sink"
+  has_many :actors,    
+    -> {order("re_artifact_relationships.position")},
+         :through => :actors_relations,  :source => "sink"
+  has_many :dependency,    
+    -> {order("re_artifact_relationships.position")},
+         :through => :dependency_relations,  :source => "sink"
+  has_many :conflict,    
+    -> {order("re_artifact_relationships.position")},
+         :through => :conflict_relations,  :source => "sink"
+  has_many :rationale,    
+    -> {order("re_artifact_relationships.position")},
+         :through => :rationale_relations,  :source => "sink"
+  has_many :refinement,    
+    -> {order("re_artifact_relationships.position")},
+         :through => :refinement_relations,  :source => "sink"
+  has_many :part_of,    
+    -> {order("re_artifact_relationships.position")},
+         :through => :part_of_relations,  :source => "sink"
+  has_many :diagram,    
+    -> { order("re_artifact_relationships.position")},
+         :through => :diagram_relations,  :source => "sink"
 
   ###
-  has_many :sources,  :through => :traces_as_sink,   :order => "re_artifact_relationships.position"
+  has_many :sources,     
+    -> {order("re_artifact_relationships.position")},
+         :through => :traces_as_sink
   has_one  :parent,   :through => :parent_relation,  :source => "source"
 
   acts_as_watchable

--- a/app/models/re_artifact_relationship.rb
+++ b/app/models/re_artifact_relationship.rb
@@ -52,13 +52,13 @@ class ReArtifactRelationship < ActiveRecord::Base
 
   def self.find_all_relations_for_artifact_id(artifact_id)
      relations = []
-     relations.concat(self.find_all_by_source_id(artifact_id))
-     relations.concat(self.find_all_by_sink_id(artifact_id))
+     relations.concat(self.where(source_id: artifact_id))
+     relations.concat(self.where(sink_id: artifact_id))
      relations.uniq
   end
   
   def scope_condition()
-    # define a seperate list for each source id and relation type
+    # define a separate list for each source id and relation type
     "#{connection.quote_column_name("source_id")} = #{quote_value(self.source_id)}
      AND
      #{connection.quote_column_name("relation_type")} = #{quote_value(self.relation_type)}"

--- a/app/models/re_artifact_relationship.rb
+++ b/app/models/re_artifact_relationship.rb
@@ -2,6 +2,8 @@ class ReArtifactRelationship < ActiveRecord::Base
   unloadable
   acts_as_list # see special scope condition below
 
+  attr_accessible :source, :sink
+
    SYSTEM_RELATION_TYPES = {
      :pch => "parentchild",
      :pac => "primary_actor",

--- a/app/models/re_relationtype.rb
+++ b/app/models/re_relationtype.rb
@@ -1,6 +1,8 @@
 class ReRelationtype < ActiveRecord::Base
   unloadable
-  
+
+  attr_accessible :is_system_relation, :is_directed, :in_use, :color
+    
   #validates :id, :presence => true, :numericality => true
   #validates :project_id, :presence => true, :numericality => true
   #validates :relation_type, :presence => true

--- a/app/models/re_relationtype.rb
+++ b/app/models/re_relationtype.rb
@@ -15,15 +15,15 @@ class ReRelationtype < ActiveRecord::Base
     tmp = nil
     if is_system_relation == nil
       if is_used_relation == nil
-         tmp = ReRelationtype.find_all_by_project_id(project_id)
+         tmp = ReRelationtype.where(project_id: project_id)
       else
-        tmp = ReRelationtype.find_all_by_project_id_and_in_use(project_id, is_used_relation)
+        tmp = ReRelationtype.where(project_id: project_id, in_use: is_used_relation)
       end  
     else
       if is_used_relation == nil
-        tmp = ReRelationtype.find_all_by_project_id_and_is_system_relation(project_id, is_system_relation)
+        tmp = ReRelationtype.where(project_id: project_id, is_system_relation: is_system_relation)
       else 
-        tmp = ReRelationtype.find_all_by_project_id_and_is_system_relation_and_in_use(project_id, is_system_relation, is_used_relation)
+        tmp = ReRelationtype.where(project_id: project_id, is_system_relation: is_system_relation, in_use: is_used_relation)
       end
     end
     tmp.each do |relationtype|

--- a/app/models/re_setting.rb
+++ b/app/models/re_setting.rb
@@ -5,6 +5,8 @@ class ReSetting < ActiveRecord::Base
   #validates_uniqueness_of :name, :scope => :project_id
   validates :name , :uniqueness => { :scope => :project_id}
 
+  attr_accessible :name, :value, :project_id
+
   # Hash used to cache setting values
   @cached_settings = {}
   @cached_cleared_on = Time.now

--- a/app/models/re_task.rb
+++ b/app/models/re_task.rb
@@ -5,7 +5,7 @@ class ReTask < ActiveRecord::Base
 
   acts_as_re_artifact
 
-  has_many :re_subtasks, :inverse_of => :re_task, :dependent => :destroy, :order => :position, :autosave => true
+  has_many :re_subtasks, -> {order( :position )}, :inverse_of => :re_task, :dependent => :destroy, :autosave => true
 
   accepts_nested_attributes_for :re_subtasks, :allow_destroy => true,
     :reject_if => proc { |attributes| attributes['name'].blank? && attributes['solution'].blank? }

--- a/app/models/re_use_case.rb
+++ b/app/models/re_use_case.rb
@@ -123,7 +123,7 @@ class ReUseCase < ActiveRecord::Base
   end 
 
  def self.getAllUserProfiles project_id
-   user_profiles = ReArtifactProperties.find_all_by_artifact_type_and_project_id('ReUserProfile', project_id)    
+   user_profiles = ReArtifactProperties.where(artifact_type: 'ReUserProfile', project_id: project_id)    
  end  
   
     

--- a/app/models/re_use_case.rb
+++ b/app/models/re_use_case.rb
@@ -5,13 +5,13 @@ class ReUseCase < ActiveRecord::Base
   
   acts_as_re_artifact
 
-  has_many :re_use_case_steps, :inverse_of => :re_use_case, :dependent => :destroy, :order => :position
+  has_many :re_use_case_steps, -> { order( :position )}, :inverse_of => :re_use_case, :dependent => :destroy
 
-  has_one :primary_actor_relation, 
+  has_one :primary_actor_relation,
+    -> { where( :re_artifact_relationships.relation_type => ReArtifactRelationship::SYSTEM_RELATION_TYPES[:pac] )}, 
     :source => :relationships_as_source,
     :through => :re_artifact_properties, 
-    :class_name => "ReArtifactRelationship", 
-    :conditions => ["re_artifact_relationships.relation_type = ?", ReArtifactRelationship::SYSTEM_RELATION_TYPES[:pac]]
+    :class_name => "ReArtifactRelationship"
 
 
   has_one :primary_actor, 
@@ -21,10 +21,10 @@ class ReUseCase < ActiveRecord::Base
 
 
   has_many :actor_relations, 
+  -> { where( :re_artifact_relationships.relation_type => ReArtifactRelationship::SYSTEM_RELATION_TYPES[:ac] )}, 
     :source => :relationships_as_source,
     :through => :re_artifact_properties, 
-    :class_name => "ReArtifactRelationship", 
-    :conditions => ["re_artifact_relationships.relation_type = ?", ReArtifactRelationship::SYSTEM_RELATION_TYPES[:ac]]
+    :class_name => "ReArtifactRelationship"
 
   has_many :actors, 
     :through => :actor_relations, 

--- a/app/models/re_visualization_config.rb
+++ b/app/models/re_visualization_config.rb
@@ -58,7 +58,7 @@ class ReVisualizationConfig < ActiveRecord::Base
 
   def self.get_artifact_filter_as_stringarray(project_id, visualization_type)
     
-    config = ReVisualizationConfig.find_all_by_project_id_and_user_id_and_visualization_type_and_configuration_type_and_configuration_value(project_id, User.current.id, visualization_type, "artifact", 1)
+    config = ReVisualizationConfig.where(project_id: project_id, user_id: User.current.id, visualization_type: visualization_type, configuration_type: "artifact", configuration_value: 1)
     @choosen_artifacts = []
     config.each do |item|
       @choosen_artifacts << item.configuration_name.camelize
@@ -70,7 +70,7 @@ class ReVisualizationConfig < ActiveRecord::Base
    
   def self.get_relation_filter_as_stringarray(project_id,visualization_type)
     
-    config = ReVisualizationConfig.find_all_by_project_id_and_user_id_and_visualization_type_and_configuration_type_and_configuration_value(project_id, User.current.id, visualization_type, "relation", 1)
+    config = ReVisualizationConfig.where(project_id: project_id, user_id: User.current.id, visualization_type: visualization_type, configuration_type: "relation", configuration_value: 1)
     @choosen_relation = []
     config.each do |item|
       @choosen_relation << item.configuration_name.camelize

--- a/app/views/re_artifact_properties/_form.html.erb
+++ b/app/views/re_artifact_properties/_form.html.erb
@@ -90,9 +90,9 @@
         <legend><%= t(:re_artifact_relationships) %></legend>
         <div class="splitcontentleft">
           <div id="relationship_link_list">
-            <% @relationships_outgoing = ReArtifactRelationship.find_all_by_source_id(@re_artifact_properties.id) %>
+            <% @relationships_outgoing = ReArtifactRelationship.where(source_id: @re_artifact_properties.id) %>
             <% @relationships_outgoing.delete_if { |rel| ReArtifactRelationship::SYSTEM_RELATION_TYPES.values.include?(rel.relation_type) } %>
-            <% @relationships_incoming = ReArtifactRelationship.find_all_by_sink_id(@re_artifact_properties.id) %>
+            <% @relationships_incoming = ReArtifactRelationship.where(sink_id: @re_artifact_properties.id) %>
             <% @relationships_incoming.delete_if { |rel| ReArtifactRelationship::SYSTEM_RELATION_TYPES.values.include?(rel.relation_type) } %>
             <%= render "re_artifact_relationship/relationship_links" %>
           </div>

--- a/app/views/re_artifact_properties/_form.html.erb
+++ b/app/views/re_artifact_properties/_form.html.erb
@@ -91,9 +91,9 @@
         <div class="splitcontentleft">
           <div id="relationship_link_list">
             <% @relationships_outgoing = ReArtifactRelationship.where(source_id: @re_artifact_properties.id) %>
-            <% @relationships_outgoing.delete_if { |rel| ReArtifactRelationship::SYSTEM_RELATION_TYPES.values.include?(rel.relation_type) } %>
+            <% @relationships_outgoing.to_a.delete_if { |rel| ReArtifactRelationship::SYSTEM_RELATION_TYPES.values.include?(rel.relation_type) } %>
             <% @relationships_incoming = ReArtifactRelationship.where(sink_id: @re_artifact_properties.id) %>
-            <% @relationships_incoming.delete_if { |rel| ReArtifactRelationship::SYSTEM_RELATION_TYPES.values.include?(rel.relation_type) } %>
+            <% @relationships_incoming.to_a.delete_if { |rel| ReArtifactRelationship::SYSTEM_RELATION_TYPES.values.include?(rel.relation_type) } %>
             <%= render "re_artifact_relationship/relationship_links" %>
           </div>
           <br/>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,42 +2,42 @@ RedmineApp::Application.routes.draw do
   resources :re_ratings
 
   match 'projects/:project_id/requirements' => 'requirements#index', :via => :get
-  match 'projects/:project_id/requirements/settings/firstload' => 're_settings#configure', :firstload => '1'
-  match 'projects/:project_id/requirements/settings' => 're_settings#configure'
-  match 'projects/:project_id/requirements/settings/:artifact_type/description/edit' => 're_settings#edit_artifact_type_description'
-  match 'projects/:project_id/requirements/settings/:artifact_type/fields/edit' => 're_settings#configure_fields'
-  match 'projects/:project_id/requirements/treefilter' => 'requirements#treefilter'
-  match 'projects/:project_id/requirements/relations/visualization/' => 're_artifact_relationship#visualization'
-  match 'projects/:project_id/requirements/relations/visualization/show/:visualization_type' => 're_artifact_relationship#build_json_according_to_user_choice'
-  match 'projects/:project_id/requirements/relations/visualization_get/:artifact_id/:visualization_type' => 're_artifact_relationship#visualization'
-  match 'projects/:project_id/requirements/tree/:mode' => 'requirements#tree'
-  match 'projects/:project_id/requirements/tree/:mode/:id' => 'requirements#tree'
+  match 'projects/:project_id/requirements/settings/firstload' => 're_settings#configure', :firstload => '1', :via => [:get, :post]
+  match 'projects/:project_id/requirements/settings' => 're_settings#configure', :via => [:get, :post]
+  match 'projects/:project_id/requirements/settings/:artifact_type/description/edit' => 're_settings#edit_artifact_type_description', :via => [:get, :post]
+  match 'projects/:project_id/requirements/settings/:artifact_type/fields/edit' => 're_settings#configure_fields', :via => [:get, :post]
+  match 'projects/:project_id/requirements/treefilter' => 'requirements#treefilter', :via => [:get, :post]
+  match 'projects/:project_id/requirements/relations/visualization/' => 're_artifact_relationship#visualization', :via => [:get, :post]
+  match 'projects/:project_id/requirements/relations/visualization/show/:visualization_type' => 're_artifact_relationship#build_json_according_to_user_choice', :via => [:get, :post]
+  match 'projects/:project_id/requirements/relations/visualization_get/:artifact_id/:visualization_type' => 're_artifact_relationship#visualization', :via => [:get, :post]
+  match 'projects/:project_id/requirements/tree/:mode' => 'requirements#tree', :via => [:get, :post]
+  match 'projects/:project_id/requirements/tree/:mode/:id' => 'requirements#tree', :via => [:get, :post]
 
-  match 'projects/requirements/tree/drop' => 'requirements#delegate_tree_drop'
-  match 'projects/:project_id/use_case/autocomplete/sink' => 're_use_case#autocomplete_sink'
-  match 'projects/:project_id/issues/new/connected_to/:artifacttype/:associationid' => 'issues#new'
-  match 'projects/:project_id/requirements/filtered_json' => 're_artifact_relationship#build_json_according_to_user_choice'
+  match 'projects/requirements/tree/drop' => 'requirements#delegate_tree_drop', :via => [:get, :post]
+  match 'projects/:project_id/use_case/autocomplete/sink' => 're_use_case#autocomplete_sink', :via => [:get, :post]
+  match 'projects/:project_id/issues/new/connected_to/:artifacttype/:associationid' => 'issues#new', :via => [:get, :post]
+  match 'projects/:project_id/requirements/filtered_json' => 're_artifact_relationship#build_json_according_to_user_choice', :via => [:get, :post]
 
   # ReArtifactProperties as "artifact"
   resources :re_artifact_properties, :except => [:new, :index]
 
-  match 're_artifact_properties/:id/recursive_destroy' => 're_artifact_properties#recursive_destroy'
-  match 're_artifact_properties/:id/how_to_delete' => 're_artifact_properties#how_to_delete'
-  match 'projects/:project_id/requirements/remove/:artifactid/from_issue/:issueid' => 're_artifact_properties#remove_artifact_from_issue'
-  match 'projects/:project_id/requirements/artifact/new/:artifact_type' => 're_artifact_properties#new'
-  match 'projects/:project_id/requirements/artifact/new/:artifact_type/inside_of/:parent_artifact_id', :to => 're_artifact_properties#new', :as => 're_artifact_properti'
-  match 'projects/:project_id/requirements/artifact/new/:artifact_type/below_of/:sibling_artifact_id' => 're_artifact_properties#new'
+  match 're_artifact_properties/:id/recursive_destroy' => 're_artifact_properties#recursive_destroy', :via => [:get, :post]
+  match 're_artifact_properties/:id/how_to_delete' => 're_artifact_properties#how_to_delete', :via => [:get, :post]
+  match 'projects/:project_id/requirements/remove/:artifactid/from_issue/:issueid' => 're_artifact_properties#remove_artifact_from_issue', :via => [:get, :post]
+  match 'projects/:project_id/requirements/artifact/new/:artifact_type' => 're_artifact_properties#new', :via => [:get, :post]
+  match 'projects/:project_id/requirements/artifact/new/:artifact_type/inside_of/:parent_artifact_id', :to => 're_artifact_properties#new', :as => 're_artifact_properti', :via => [:get, :post]
+  match 'projects/:project_id/requirements/artifact/new/:artifact_type/below_of/:sibling_artifact_id' => 're_artifact_properties#new', :via => [:get, :post]
 
-  match 'projects/:project_id/requirements/autcomplete' => 're_artifact_properties#autocomplete_artifact'
-  match 'projects/:project_id/requirements/artifact/autocomplete/issue' => 're_artifact_properties#autocomplete_issue'
-  match 'projects/:project_id/requirements/artifact/autocomplete/artifact' => 're_artifact_properties#autocomplete_artifact'
+  match 'projects/:project_id/requirements/autcomplete' => 're_artifact_properties#autocomplete_artifact', :via => [:get, :post]
+  match 'projects/:project_id/requirements/artifact/autocomplete/issue' => 're_artifact_properties#autocomplete_issue', :via => [:get, :post]
+  match 'projects/:project_id/requirements/artifact/autocomplete/artifact' => 're_artifact_properties#autocomplete_artifact', :via => [:get, :post]
 
-  match 'projects/:project_id/requirements/artifact/new_comment/:id' => 're_artifact_properties#new_comment'
+  match 'projects/:project_id/requirements/artifact/new_comment/:id' => 're_artifact_properties#new_comment', :via => [:get, :post]
 
-  match ':project_id/:id/:re_artifact_properties_id/delete' => 're_artifact_relationship#delete'
-  match 'projects/:project_id/ralation/prepare/:id' => 're_artifact_relationship_controller#prepare_relationships'
-  match 'projects/:project_id/ralation/autocomplete/sink/:id' => 're_artifact_relationship_controller#autocomplete_sink'
-  match '/relation/add' => 'requirements#add_relation'
+  match ':project_id/:id/:re_artifact_properties_id/delete' => 're_artifact_relationship#delete', :via => [:get, :post]
+  match 'projects/:project_id/ralation/prepare/:id' => 're_artifact_relationship_controller#prepare_relationships', :via => [:get, :post]
+  match 'projects/:project_id/ralation/autocomplete/sink/:id' => 're_artifact_relationship_controller#autocomplete_sink', :via => [:get, :post]
+  match '/relation/add' => 'requirements#add_relation', :via => [:get, :post]
 
   match 'projects/:project_id/re_queries' => 're_queries#index', :via => :get
   match 'projects/:project_id/re_queries/:id/delete' => 're_queries#delete', :via => :get
@@ -59,5 +59,5 @@ RedmineApp::Application.routes.draw do
 
   end
 
-  match "projects/:project_id/diagram_preview/:diagram_id" => 'requirements#sendDiagramPreviewImage'
+  match "projects/:project_id/diagram_preview/:diagram_id" => 'requirements#sendDiagramPreviewImage', :via => [:get, :post]
 end

--- a/db/migrate/031_add_name_and_position_to_subtasks.rb
+++ b/db/migrate/031_add_name_and_position_to_subtasks.rb
@@ -19,14 +19,14 @@ class AddNameAndPositionToSubtasks < ActiveRecord::Migration
         st.valid?
         say "there might be some inconsistencies in your DB since the subtask could not be saved: #{st.errors.inspect}" unless st.save
 
-        ReArtifactRelationship.find_all_by_source_id(properties.id).each do |r|
+        ReArtifactRelationship.where( source_id: properties.id ).each do |r|
           unless r.relation_type == "parentchild"
             say "moving incoming subtask relation #{r.inspect} to parent task #{parent_task_properties.inspect}"
             r.source_id = parent_task_properties.id
             r.save
           end
         end
-        ReArtifactRelationship.find_all_by_sink_id(properties.id).each do |r|
+        ReArtifactRelationship.where( sink_id: properties.id ).each do |r|
           unless r.relation_type == "parentchild"
             say "moving incoming subtask relation #{r.inspect} to parent task #{parent_task_properties.inspect}"
             r.sink_id = parent_task_properties.id
@@ -45,7 +45,7 @@ class AddNameAndPositionToSubtasks < ActiveRecord::Migration
       parent_relation = ReArtifactRelationship.find_by_sink_id_and_relation_type(properties.id, "parentchild")
       parent_relation.destroy
     end
-    ReArtifactProperties.find_all_by_artifact_type("ReSubtask").each{ |p| ReArtifactProperties.delete(p.id) }
+    ReArtifactProperties.where( artifact_type: "ReSubtask" ).each{ |p| ReArtifactProperties.delete(p.id) }
 
   end
 

--- a/db/migrate/20130913000000_move_to_requirement_and_remove_re_attachment.rb
+++ b/db/migrate/20130913000000_move_to_requirement_and_remove_re_attachment.rb
@@ -4,7 +4,7 @@ end
 class MoveToRequirementAndRemoveReAttachment < ActiveRecord::Migration
 
   def self.up
-    ReArtifactProperties.find_all_by_artifact_type("ReAttachment").each do |artifact|
+    ReArtifactProperties.where(artifact_type: "ReAttachment").each do |artifact|
 
       # Find each ReAttachment and
       # change its container_type to ReArtifactProperties and its ID to the artifact id
@@ -33,7 +33,7 @@ class MoveToRequirementAndRemoveReAttachment < ActiveRecord::Migration
     end
 
     # Remove Setting from array
-    artifact_order = ReSetting.find_all_by_name("artifact_order")
+    artifact_order = ReSetting.where(name: "artifact_order")
     unless artifact_order.nil? 
       artifact_order.each do |artifact_order_setting|
         stored_settings = ReSetting.get_serialized("artifact_order", artifact_order_setting.project_id)

--- a/db/migrate/20130918000000_reconfigure_plugin_after_removing_re_attachments.rb
+++ b/db/migrate/20130918000000_reconfigure_plugin_after_removing_re_attachments.rb
@@ -11,7 +11,7 @@ class ReconfigurePluginAfterRemovingReAttachments < ActiveRecord::Migration
     end
     
     # Remove Setting from array
-    ReSetting.find_all_by_name("artifact_order").each do |artifact_order_setting|
+    ReSetting.where(name: "artifact_order").each do |artifact_order_setting|
       stored_settings = ReSetting.get_serialized("artifact_order", artifact_order_setting.project_id)
       stored_settings.delete("re_attachment")
       ReSetting.set_serialized("artifact_order", artifact_order_setting.project_id, stored_settings)


### PR DESCRIPTION
I made a lot of progress towards getting the plugin to run in Redmine 3.0 with Rails 4.2.1.  Replaced now obsolete find_all_by_* methods with where(), replaced :order with a scoped call to order, replaced :conditions with a scoped call to where(), and some other odds and ends.  

Unfortunately, this is my first time working with Ruby and Rails so I'm not confident that they were the correct changes, merely the changes that got it to work past a certain point.

Right now, trying to save a newly created Vision fails (this is probably true for all artifacts) with an error that I'm still looking into.  But I thought that by eliminating many of the easier problems, someone else might make headway on this.