### PR TITLE
ReSetting::ARTIFACT_TYPES clone

### DIFF
--- a/app/controllers/re_settings_controller.rb
+++ b/app/controllers/re_settings_controller.rb
@@ -103,7 +103,7 @@ private
     # Put it into the empty configured_artifact_types array
     configured_artifact_types.concat(stored_settings) if stored_settings
 
-    all_artifact_types = ReSetting::ARTIFACT_TYPES
+    all_artifact_types = ReSetting::ARTIFACT_TYPES.clone
     all_artifact_types.delete_if { |v| configured_artifact_types.include? v }
     configured_artifact_types.concat(all_artifact_types)
 

--- a/assets/stylesheets/icons.css
+++ b/assets/stylesheets/icons.css
@@ -7,7 +7,7 @@ a.icon {
     background-repeat: no-repeat !important;
 }
 
-.project {
+.re_project {
     background: url(../images/icons/group_gear.png);
 }
 


### PR DESCRIPTION
There is a problem in lines 106-107 (    all_artifact_types.delete_if { |v| configured_artifact_types.include? v }   ). If you add Requirements module to a project and save settings, then when you try to do the same thing in another project - ReSetting::ARTIFACT_TYPES is empty. I suggest cloning ReSetting::ARTIFACT_TYPES before delete_if in this context.

Failing use case:
1. Enable Requirements in project A.
2. Go to Requirements in project A, save settings.
3. Enable Requirements in project B.
4. Go to Requirements in project B, list of artifact types is empty. Save causes internal error.